### PR TITLE
Prevent old-style-definition compile errors

### DIFF
--- a/src/formats/amiga_ext/snprintf.c
+++ b/src/formats/amiga_ext/snprintf.c
@@ -4,8 +4,8 @@
  * @version 3.8.0
  */
 
-/* MSVC CRT already provides snprintf/vsnprintf - skip this entire file */
-#if defined(_MSC_VER)
+/* MSVC CRT and Linux already provides snprintf/vsnprintf - skip this entire file */
+#if defined(_MSC_VER) || defined(__linux__)
 /* nothing */
 #else
 
@@ -277,4 +277,4 @@ static void dopr_outch( c )
        }
 }
 
-#endif /* !_MSC_VER */
+#endif /* !_MSC_VER || !__linux__ */


### PR DESCRIPTION
Prevent old-style-definition compile errors

```
../src/formats/amiga_ext/snprintf.c: In function ‘vsnprintf’:
../src/formats/amiga_ext/snprintf.c:42:5: warning: old-style function definition [-Wold-style-definition]
   42 | int vsnprintf(str, count, fmt, args)
      |     ^~~~~~~~~
../src/formats/amiga_ext/snprintf.c:50:8: error: too many arguments to function ‘dopr’; expected 0, have 3
   50 |        dopr( str, fmt, args );
      |        ^~~~  ~~~
../src/formats/amiga_ext/snprintf.c:30:13: note: declared here
   30 | static void dopr();
      |             ^~~~
../src/formats/amiga_ext/snprintf.c: In function ‘dopr’:
../src/formats/amiga_ext/snprintf.c:82:13: warning: old-style function definition [-Wold-style-definition]
   82 | static void dopr( buffer, format, args )
      |             ^~~~
../src/formats/amiga_ext/snprintf.c: In function ‘fmtstr’:
../src/formats/amiga_ext/snprintf.c:175:1: warning: old-style function definition [-Wold-style-definition]
  175 | fmtstr(  value, ljust, len, zpad )
      | ^~~~~~
../src/formats/amiga_ext/snprintf.c: In function ‘fmtnum’:
../src/formats/amiga_ext/snprintf.c:200:1: warning: old-style function definition [-Wold-style-definition]
  200 | fmtnum(  value, base, dosign, ljust, len, zpad )
      | ^~~~~~
../src/formats/amiga_ext/snprintf.c: In function ‘dostr’:
../src/formats/amiga_ext/snprintf.c:259:13: warning: old-style function definition [-Wold-style-definition]
  259 | static void dostr( str )
      |             ^~~~~
../src/formats/amiga_ext/snprintf.c: In function ‘dopr_outch’:
../src/formats/amiga_ext/snprintf.c:265:13: warning: old-style function definition [-Wold-style-definition]
  265 | static void dopr_outch( c )
      |             ^~~~~~~~~~
```
