### PR TITLE
Fix build under GCC 15

### DIFF
--- a/src/formats/amiga_ext/snprintf.c
+++ b/src/formats/amiga_ext/snprintf.c
@@ -26,7 +26,6 @@
  * causing nast effects.
  **************************************************************/
 
-static void dopr();
 static char *end;
 
 #include <sys/types.h>
@@ -37,6 +36,8 @@ static char *end;
 /* varargs declarations: */
 
 #include "snprintf.h"
+
+static void dopr( char *buffer, char *format, va_list args );
 
 int vsnprintf(str, count, fmt, args)
        char *str;


### PR DESCRIPTION
GCC 15 defaults to the GNU23 C standard, which means that function declarations without parameters don't work anymore.

```
src/formats/amiga_ext/snprintf.c:49:8: error: too many arguments to function ‘dopr’; expected 0, have 3
   49 |        dopr( str, fmt, args );
      |        ^~~~  ~~~
src/formats/amiga_ext/snprintf.c:29:13: note: declared here
   29 | static void dopr();
      |             ^~~~
```

See https://gcc.gnu.org/gcc-15/porting_to.html#c23