### PR TITLE
ci: Dependabot woechentlich, mit zwei Gruppen (MF-802)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,34 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      # Minor/Patch gesammelt in einem PR -- kleine Diffs, ein Review.
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      # upload-/download-artifact muessen paarweise springen: release.yml
+      # laedt in den Build-Jobs hoch und im create-release-Job wieder
+      # herunter. Ein einseitiger Major-Bump zerreisst den Release-Pfad.
+      #
+      # MF-801 hat genau diese Lage hergestellt und sie ist KEIN Fehler:
+      # hochgeladen wird mit upload@v7, heruntergeladen mit download@v8.
+      # Die beiden Majors sind nicht deckungsgleich, weil die Projekte
+      # verschieden schnell zaehlen. Die Gruppe sorgt dafuer, dass der
+      # naechste Sprung wieder GEMEINSAM zur Entscheidung kommt statt
+      # einzeln durchzurutschen.
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"


### PR DESCRIPTION
Vom Eigentuemer geliefert, unveraendert uebernommen bis auf einen ergaenzten Kommentar.

  monatlich -> woechentlich (Montag 06:00, Europe/Berlin)
  open-pull-requests-limit: 5
  commit-message prefix "ci", Labels dependencies + ci
  Gruppe actions-minor-patch: Minor und Patch gesammelt in EINEN PR
  Gruppe artifact-actions:    upload- und download-artifact zusammen

Die zweite Gruppe ist die inhaltlich tragende: `release.yml` laedt in den Build-Jobs hoch und im create-release-Job wieder herunter. Ein einseitiger Major-Bump zerreisst den Release-Pfad, und zwar erst beim naechsten Tag — also lange nach dem Merge.

## Der ergaenzte Kommentar

MF-801 hat genau die Lage hergestellt, gegen die diese Gruppe schuetzt, und sie ist KEIN Fehler: hochgeladen wird jetzt mit `upload-artifact@v7`, heruntergeladen mit `download-artifact@v8`. Die beiden Majors sind nicht deckungsgleich, weil die Projekte verschieden schnell zaehlen — download-artifact hatte v6 im Oktober 2025 und v7 im Dezember, waehrend upload-artifact erst im April 2026 bei v7 ankam.

Wer die Gruppe spaeter liest und „paarweise springen" als „gleiche Nummer" versteht, wuerde einen Fehler suchen, den es nicht gibt. Der Kommentar sagt jetzt, dass die Gruppe fuer GEMEINSAME ENTSCHEIDUNG sorgt, nicht fuer gleiche Zahlen.

Kennzahl (Regel 9): keine der vier.


Claude-Session: https://claude.ai/code/session_01BHdqfaZ5RFb1HPcw7NYoEY