### PR TITLE
ci: Action-Majors angehoben — upload v7, download v8, gh-release v3 (…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload parity log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gw-parity-log-${{ github.sha }}
           path: parity.log
@@ -256,7 +256,7 @@ jobs:
 
       - name: Upload build logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-build-logs-${{ matrix.qt_version }}-${{ github.sha }}
           path: |
@@ -299,7 +299,7 @@ jobs:
 
       - name: Upload build logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-build-logs-${{ github.sha }}
           path: build/*.log
@@ -408,7 +408,7 @@ jobs:
 
       - name: Upload build logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-build-logs-${{ github.sha }}
           path: build/*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
           dpkg-deb --build "${PKG}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-release
           path: |
@@ -199,7 +199,7 @@ jobs:
           tar czf "${DIST}.tar.gz" "${DIST}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-release
           path: |
@@ -288,7 +288,7 @@ jobs:
           tar czf "${DIST}.tar.gz" "${DIST}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-release
           path: UnifiedFloppyTool-*-windows-x64.tar.gz
@@ -311,7 +311,7 @@ jobs:
         run: echo "version=$(cat VERSION.txt | tr -d '[:space:]')" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-artifacts
           merge-multiple: true
@@ -327,7 +327,7 @@ jobs:
           cat ../SHA256SUMS.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # Name + prerelease flag derive from the git tag, not VERSION.txt:
           # VERSION.txt is numeric-only (4.1.4) and cannot carry an -rc/-beta

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload ASan findings
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: asan-findings-${{ github.sha }}
           path: |
@@ -192,7 +192,7 @@ jobs:
 
       - name: Upload UBSan findings
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ubsan-findings-${{ github.sha }}
           path: |


### PR DESCRIPTION
…MF-801)

Vom Eigentuemer als Patch geliefert, hier nachgemessen statt angewandt. Zwei Abweichungen vom Patch, beide begruendet.

## ABWEICHUNG 1: es sind neun upload-Stellen, nicht acht

Der Patch stammt aus einem Baum vor MF-798. Der `gw-parity`-Job hat seither eine neunte Fundstelle (`ci.yml:124`) hinzugefuegt. `git apply` haette sie stehen lassen und einen GEMISCHTEN Zustand hinterlassen — zehn Stellen auf dem neuen Major, eine auf v4.

Deshalb per `sed` ueber alle Fundstellen statt per Patch ueber Zeilennummern. Gemessen danach: 9x upload@v7, 1x download@v8, 1x gh-release@v3, kein v4/v2 mehr uebrig.

## ABWEICHUNG 2: nicht nach main

Der Eigentuemer hat den Weg vorgezeichnet — eigener Branch, und der Release-Pfad einmal auf einem RC-Tag durchziehen, BEVOR das nach main geht. Das steht so, und es ist richtig: die beiden Verhaltens- aenderungen unten treffen genau den Release-Pfad.

## Die Zahlen sind nachgesehen, nicht uebernommen

Ueber die GitHub-API am 2026-09-02:

  actions/upload-artifact     v7.0.1 (2026-04-10) — v7 existiert
  actions/download-artifact   v8.0.1 (2026-03-11) — v8 existiert
  softprops/action-gh-release v3.0.3             — v3 existiert

Und die `with:`-Bloecke bleiben unveraendert gueltig: `name`/`path`/ `retention-days` bei upload; `path`/`merge-multiple` bei download; `name`/`body_path`/`draft`/`prerelease`/`files` bei gh-release — letztere fuenf einzeln in `action.yml` der v3 nachgesehen.

Zwei Verhaltensaenderungen, beide bestaetigt:

  download-artifact v8.0.0 fuehrt `digest-mismatch` ein, Default `error`
    („To be secure by default, we are now defaulting the behavior to
    `error` which will fail the workflow run.")
  action-gh-release v3 hat `overwrite_files` mit Default 'true' — in
    action.yml nachgesehen, NICHT in den Release-Notes, die es nicht
    erwaehnen. Bei einem Re-Run auf demselben Tag werden Assets damit
    ueberschrieben statt zu kollidieren.

## Eine Frage, die ich NICHT beantworten kann

Der Patchtext sagt „Laeuft Upload und Download ueber dieselben Majors, passt das". Hier laufen sie NICHT ueber dieselben Majors: hochgeladen wird mit v7, heruntergeladen mit v8. Ob v7 die Pruefsumme in der Form schreibt, die v8s `digest-mismatch` erwartet, ist ohne Lauf nicht feststellbar — und genau deshalb ist der RC-Durchlauf keine Formalie. Faellt es aus, ist der Ausweg `digest-mismatch: warn` an der einen Stelle, nicht ein Rueckbau.

Kennzahl (Regel 9): keine der vier. Wartungsarbeit an der Infrastruktur, die die vier misst.


Claude-Session: https://claude.ai/code/session_01BHdqfaZ5RFb1HPcw7NYoEY